### PR TITLE
Search Term "*" To Match Every Event

### DIFF
--- a/apps/gcal-search-trigger.groovy
+++ b/apps/gcal-search-trigger.groovy
@@ -116,7 +116,7 @@ def getNextEvents() {
             for (int i = 0; i < items.size(); i++) {
                 def eventTitle = items[i].eventTitle
                 
-                if (searchTerm.indexOf("*") > -1) {
+                if (searchTerm.indexOf("*") > -1 && searchTerm != "*") {
                     def searchList = searchTerm.toString().split("\\*")
                     for (int sL = 0; sL < searchList.size(); sL++) {
                         def searchItem = searchList[sL].trim()
@@ -133,7 +133,7 @@ def getNextEvents() {
                         break
                     }
                 } else {
-                    if (eventTitle.startsWith(searchTerm)) {
+                    if (eventTitle.startsWith(searchTerm) || searchTerm == "*") {
                         foundMatch = true
                         item = items[i]
                         break


### PR DESCRIPTION
The reason for this is that I have a separate calendar that is already full of every event that should turn on the virtual switch.  Others may have a similar situation where they sync a work calendar to their google calendar and they want every meeting/event in the calendar to turn on a switch.

I made a simple change to allow "*" to match every event in the calendar.